### PR TITLE
Small cleanup & optimizations for quicksort

### DIFF
--- a/src/Data/Array/Accelerate/Data/Sort/Quick.hs
+++ b/src/Data/Array/Accelerate/Data/Sort/Quick.hs
@@ -66,17 +66,21 @@ step cmp (T2 values headFlags) = T2 values' headFlags'
     startIndex = propagateSegmentHead headFlags (generate (shape values) unindex1)
 
     -- Compute the offsets to which the elements must be moved using a scan
-    indicesLarger, indicesSmaller :: Acc (Vector Int)
-    indicesLarger  = map (\x -> x - 1) $ postscanSegHead (+) headFlags $ map (? (1, 0)) isLarger
-    indicesSmaller = map (\x -> x - 1) $ postscanSegHead (+) headFlags $ map (? (0, 1)) isLarger
+    -- The array contains tuples. The first element is the offset among
+    -- the larger elements (ie the number of elements before this element,
+    -- which also belong to the larger-than segment), and the second element
+    -- is the offset among the smaller elements.
+    -- Since we use an inclusive scan, the indices are one too large (hence the name PlusOne)
+    indicesLargerSmallerPlusOne :: Acc (Vector (Int, Int))
+    indicesLargerSmallerPlusOne = postscanSegHead (\(T2 a b) (T2 c d) -> T2 (a + c) (b + d)) headFlags $ map (? (T2 1 0, T2 0 1)) isLarger
 
     -- Propagate the number of smaller elements to each segment
     -- This is needed as an offset for the larger elements
     countSmaller :: Acc (Vector Int)
-    countSmaller = propagateSegmentLast headFlags $ map (+1) indicesSmaller
+    countSmaller = propagateSegmentLast headFlags $ map snd indicesLargerSmallerPlusOne
 
     -- Compute the new indices of the elements
-    permutation = zipWith5 partitionPermuteIndex isLarger startIndex indicesSmaller indicesLarger countSmaller
+    permutation = zipWith4 partitionPermuteIndex isLarger startIndex indicesLargerSmallerPlusOne countSmaller
 
     -- Perform the permutation
     values' = scatter permutation (fill (shape values) undef) values
@@ -111,9 +115,9 @@ condition (T2 _ headFlags) = any not headFlags
 -- Finds the new index of an element of the list, as the result of the
 -- partition
 --
-partitionPermuteIndex :: Exp Bool -> Exp Int -> Exp Int -> Exp Int -> Exp Int -> Exp Int
-partitionPermuteIndex isLarger start indexIfSmaller indexIfLarger countSmaller =
-  start + (isLarger ? (countSmaller + indexIfLarger, indexIfSmaller))
+partitionPermuteIndex :: Exp Bool -> Exp Int -> Exp (Int, Int) -> Exp Int -> Exp Int
+partitionPermuteIndex isLarger start (T2 indexIfLarger indexIfSmaller) countSmaller =
+  start + (isLarger ? (countSmaller + indexIfLarger - 1, indexIfSmaller - 1))
 
 -- Given head flags, propagates the value of the head to all elements in
 -- the segment


### PR DESCRIPTION
I did some cleanup and optimizations for the quicksort implementation:

- The segmented scans now use a '1' variant (without an initial value) as the initial value was the identity of the operator.
- Manually fused two scans
- Tuned some code for fusion, by not performing maps after scans